### PR TITLE
The scope of the unsafe blocks can be appropriately reduced

### DIFF
--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -162,16 +162,14 @@ impl ThreadPool {
     /// [snt]: struct.ThreadPoolBuilder.html#method.num_threads
     #[inline]
     pub fn current_thread_index(&self) -> Option<usize> {
-        unsafe {
             let curr = WorkerThread::current();
             if curr.is_null() {
                 None
-            } else if (*curr).registry().id() != self.registry.id() {
+            } else if unsafe { (*curr).registry().id() != self.registry.id() }{
                 None
             } else {
-                Some((*curr).index())
+                unsafe { Some((*curr).index()) }
             }
-        }
     }
 
     /// Returns true if the current worker thread currently has "local
@@ -197,16 +195,14 @@ impl ThreadPool {
     /// [deque]: https://en.wikipedia.org/wiki/Double-ended_queue
     #[inline]
     pub fn current_thread_has_pending_tasks(&self) -> Option<bool> {
-        unsafe {
             let curr = WorkerThread::current();
             if curr.is_null() {
                 None
-            } else if (*curr).registry().id() != self.registry.id() {
+            } else if unsafe { (*curr).registry().id() != self.registry.id() }{
                 None
             } else {
-                Some(!(*curr).local_deque_is_empty())
+                unsafe { Some(!(*curr).local_deque_is_empty()) }
             }
-        }
     }
 
     /// Execute `oper_a` and `oper_b` in the thread-pool and return
@@ -289,12 +285,12 @@ impl fmt::Debug for ThreadPool {
 /// [snt]: struct.ThreadPoolBuilder.html#method.num_threads
 #[inline]
 pub fn current_thread_index() -> Option<usize> {
+    let curr = WorkerThread::current();
     unsafe {
-        let curr = WorkerThread::current();
         if curr.is_null() {
             None
         } else {
-            Some((*curr).index())
+            unsafe { Some((*curr).index()) }
         }
     }
 }
@@ -307,12 +303,12 @@ pub fn current_thread_index() -> Option<usize> {
 /// [m]: struct.ThreadPool.html#method.current_thread_has_pending_tasks
 #[inline]
 pub fn current_thread_has_pending_tasks() -> Option<bool> {
+    let curr = WorkerThread::current();
     unsafe {
-        let curr = WorkerThread::current();
         if curr.is_null() {
             None
         } else {
-            Some(!(*curr).local_deque_is_empty())
+            unsafe { Some(!(*curr).local_deque_is_empty()) }
         }
     }
 }

--- a/rayon-core/src/util.rs
+++ b/rayon-core/src/util.rs
@@ -1,10 +1,10 @@
 use std::mem;
 
 pub fn leak<T>(v: T) -> &'static T {
+    let b = Box::new(v);
+    let p: *const T = &*b;
+    mem::forget(b); // leak our reference, so that `b` is never freed
     unsafe {
-        let b = Box::new(v);
-        let p: *const T = &*b;
-        mem::forget(b); // leak our reference, so that `b` is never freed
         &*p
     }
 }

--- a/src/slice/quicksort.rs
+++ b/src/slice/quicksort.rs
@@ -430,17 +430,15 @@ where
         // Find the first pair of out-of-order elements.
         let mut l = 0;
         let mut r = v.len();
-        unsafe {
             // Find the first element greater then or equal to the pivot.
-            while l < r && is_less(v.get_unchecked(l), pivot) {
+            while l < r && is_less(unsafe { v.get_unchecked(l) }, pivot) {
                 l += 1;
             }
 
             // Find the last element smaller that the pivot.
-            while l < r && !is_less(v.get_unchecked(r - 1), pivot) {
+            while l < r && !is_less(unsafe { v.get_unchecked(r - 1) }, pivot) {
                 r -= 1;
             }
-        }
 
         (
             l + partition_in_blocks(&mut v[l..r], pivot, is_less),
@@ -483,14 +481,13 @@ where
     let mut l = 0;
     let mut r = v.len();
     loop {
-        unsafe {
             // Find the first element greater that the pivot.
-            while l < r && !is_less(pivot, v.get_unchecked(l)) {
+            while l < r && !is_less(pivot, unsafe { v.get_unchecked(l) }) {
                 l += 1;
             }
 
             // Find the last element equal to the pivot.
-            while l < r && is_less(pivot, v.get_unchecked(r - 1)) {
+            while l < r && is_less(pivot, unsafe { v.get_unchecked(r - 1) }) {
                 r -= 1;
             }
 
@@ -501,9 +498,8 @@ where
 
             // Swap the found pair of out-of-order elements.
             r -= 1;
-            ptr::swap(v.get_unchecked_mut(l), v.get_unchecked_mut(r));
+            unsafe { ptr::swap(v.get_unchecked_mut(l), v.get_unchecked_mut(r)) };
             l += 1;
-        }
     }
 
     // We found `l` elements equal to the pivot. Add 1 to account for the pivot itself.

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -54,17 +54,15 @@ impl<T: Send> IndexedParallelIterator for IntoIter<T> {
     {
         // The producer will move or drop each item from its slice, effectively taking ownership of
         // them.  When we're done, the vector only needs to free its buffer.
-        unsafe {
             // Make the vector forget about the actual items.
             let len = self.vec.len();
-            self.vec.set_len(0);
+            unsafe { self.vec.set_len(0) };
 
             // Get a correct borrow, then extend it to the original length.
             let mut slice = self.vec.as_mut_slice();
-            slice = std::slice::from_raw_parts_mut(slice.as_mut_ptr(), len);
+            unsafe { slice = std::slice::from_raw_parts_mut(slice.as_mut_ptr(), len) };
 
             callback.callback(VecProducer { slice: slice })
-        }
     }
 }
 


### PR DESCRIPTION
In these functions you use the unsafe keyword for many safe expressions. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 


Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 